### PR TITLE
Add priorityClassName of system-node-critical

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -24,3 +24,4 @@ spec:
         - name: host-etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+      priorityClassName: system-node-critical


### PR DESCRIPTION
So that pods from this Daemonset on each node will be given priority scheduling.

From [the docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#effect-of-pod-priority-on-scheduling-order):
> In Kubernetes 1.9 and later, when Pod priority is enabled, scheduler orders pending Pods by their priority and a pending Pod is placed ahead of other pending Pods with lower priority in the scheduling queue. As a result, the higher priority Pod may be scheduled sooner than Pods with lower priority if its scheduling requirements are met.